### PR TITLE
Let 'onSuccess' and 'onFailure' throw exceptions

### DIFF
--- a/src/main/java/com/jasongoodwin/monads/Try.java
+++ b/src/main/java/com/jasongoodwin/monads/Try.java
@@ -115,16 +115,18 @@ public abstract class Try<T> {
      * Performs the provided action, when successful
      * @param action action to run
      * @return new composed Try
+     * @throws E if the action throws an exception
      */
-    public abstract Try<T> onSuccess(Consumer<T> action);
+    public abstract <E extends Throwable> Try<T> onSuccess(TryConsumer<T, E> action) throws E;
 
     /**
      * Performs the provided action, when failed
      * @param action action to run
      * @return new composed Try
+     * @throws E if the action throws an exception
      */
-    public abstract Try<T> onFailure(Consumer<Throwable> action);
-
+    public abstract <E extends Throwable> Try<T> onFailure(TryConsumer<Throwable, E> action) throws E;
+    
     /**
      * If a Try is a Success and the predicate holds true, the Success is passed further.
      * Otherwise (Failure or predicate doesn't hold), pass Failure.
@@ -224,9 +226,9 @@ class Success<T> extends Try<T> {
     }
 
     @Override
-    public Try<T> onSuccess(Consumer<T> action) {
-        action.accept(value);
-        return this;
+    public <E extends Throwable> Try<T> onSuccess(TryConsumer<T, E> action) throws E {
+      action.accept(value);
+      return this;
     }
 
     @Override
@@ -246,8 +248,8 @@ class Success<T> extends Try<T> {
     }
 
     @Override
-    public Try<T> onFailure(Consumer<Throwable> action) {
-        return this;
+    public <E extends Throwable> Try<T> onFailure(TryConsumer<Throwable, E> action) {
+      return this;
     }
 }
 
@@ -309,10 +311,10 @@ class Failure<T> extends Try<T> {
     }
 
     @Override
-    public Try<T> onSuccess(Consumer<T> action) {
-        return this;
+    public <E extends Throwable> Try<T> onSuccess(TryConsumer<T, E> action) {
+      return this;
     }
-
+    
     @Override
     public Try<T> filter(Predicate<T> pred) {
         return this;
@@ -323,9 +325,9 @@ class Failure<T> extends Try<T> {
         return Optional.empty();
     }
    
-    @Override 
-    public Try<T> onFailure(Consumer<Throwable> action) {
-        action.accept(e);
-        return this;
+    @Override
+    public <E extends Throwable> Try<T> onFailure(TryConsumer<Throwable, E> action) throws E {
+      action.accept(e);
+      return this;
     }
 }

--- a/src/main/java/com/jasongoodwin/monads/TryConsumer.java
+++ b/src/main/java/com/jasongoodwin/monads/TryConsumer.java
@@ -1,0 +1,19 @@
+package com.jasongoodwin.monads;
+
+/**
+ * This is similar to the Java {@link java.util.function.Consumer Consumer} function type.
+ * It has a checked exception on it to allow it to be used in lambda expressions on the Try monad.
+ * 
+ * @param <T>
+ * @param <E> the type of throwable thrown by {@link #accept(Object)}
+ */
+public interface TryConsumer<T, E extends Throwable> {
+
+  /**
+   * Performs this operation on the given argument.
+   *
+   * @param t the input argument
+   */
+  void accept(T t) throws E;
+
+}

--- a/src/test/java/com/jasongoodwin/monads/TryTest.java
+++ b/src/test/java/com/jasongoodwin/monads/TryTest.java
@@ -183,5 +183,46 @@ public class TryTest {
 
         assertTrue(opt1.isPresent());
     }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowExceptionFromTryConsumerOnSuccessIfSuccess() throws Throwable {
+        Try<String> t = Try.ofFailable(() -> "hey");
+      
+        t.onSuccess(s -> {
+          throw new IllegalArgumentException("Should be thrown.");
+        });
+    }
+    
+    @Test
+    public void itShouldNotThrowExceptionFromTryConsumerOnSuccessIfFailure() throws Throwable {
+        Try<String> t = Try.ofFailable(() -> {
+            throw new IllegalArgumentException("Expected exception");
+        });
+      
+        t.onSuccess(s -> {
+          throw new IllegalArgumentException("Should NOT be thrown.");
+        });
+    }
+    
+    @Test
+    public void itShouldNotThrowExceptionFromTryConsumerOnFailureIfSuccess() throws Throwable {
+        Try<String> t = Try.ofFailable(() -> "hey");
+      
+        t.onFailure(s -> {
+          throw new IllegalArgumentException("Should NOT be thrown.");
+        });
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowExceptionFromTryConsumerOnFailureIfFailure() throws Throwable {
+        Try<String> t = Try.ofFailable(() -> {
+            throw new IllegalArgumentException("Expected exception");
+        });
+      
+        t.onFailure(s -> {
+            throw new IllegalArgumentException("Should be thrown.");
+        });
+    }
+    
 }
 


### PR DESCRIPTION
I started using `Try` and really liked working with it. But `onSuccess` and `onFailure` I wanted to call exception throwing methods[1]. This is currently not possible without jumping through some fairly uncomfortable hoops. Alternatively I could use `isSuccess` but this breaks fluency which Is a shame.

Would you consider letting those methods accept an exception throwing `Consumer`?

[1] I guess from a functional programming point of view calling an exception throwing method from a Try-monad could be considered to contradict the type's intention. But if using this monad in an existing non-FP code base, there might sometimes be no other choice.