### PR TITLE
added basic osgi/MANIFEST.MF support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,17 @@ libraryDependencies ++= Seq(
   "junit" % "junit" % "4.11" % "test"
 )
 
+lazy val thisProject = (project in file ("."))
+  .enablePlugins(SbtOsgi)
+
+osgiSettings
+
+OsgiKeys.bundleSymbolicName := "com.jasongoodwin.monads"
+
+OsgiKeys.exportPackage := Seq("com.jasongoodwin.monads")
+
+OsgiKeys.privatePackage := Seq.empty
+
 crossPaths := false
 
 publishMavenStyle := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.1")


### PR DESCRIPTION
These changes provide an `Export-Package` attribute in the generated MANIFEST.MF, which allows the compiled jar to be used in OSGi projects.