### PR TITLE
raise() method to expose(throw) exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The Try api is meant to be similar to the Optional type so has the same function
 - filter((x) -> isTrue(x)) - If Success, returns the same Success if the predicate succeeds, otherwise, returns a Failure with type NoSuchElementException.
 - onSuccess((x) -> f(x)) execute some code on success - takes Consumer (eg requires no return value).
 - onFailure((x) -> f(x)) execute some code on failure - takes Consumer (eg requires no return value).
+- raise(x) -> will throw an exception of type x when it happens
 - orElse(x) will return the success value of the Try in success case or the value x in failure case.
 - orElseTry(f) will return the success value of the Try in success case or a new Try(f) in the failure case.
 - orElseThrow(() -> throw new T) gets result or on failure will throw checked exception of type T

--- a/src/main/java/com/jasongoodwin/monads/Try.java
+++ b/src/main/java/com/jasongoodwin/monads/Try.java
@@ -143,6 +143,14 @@ public abstract class Try<T> {
     public abstract <E extends Throwable> Try<T> onFailure(TryConsumer<Throwable, E> action) throws E;
 
     /**
+     * When the clazz failure type happens, that exception is thrown
+     * @param clazz the expected exception class
+     * @return new composed Try
+     * @throws E if the failure type is the on provided
+     */
+    public abstract <E extends Throwable> Try<T> raise(Class<E> clazz) throws E;
+
+    /**
      * If a Try is a Success and the predicate holds true, the Success is passed further.
      * Otherwise (Failure or predicate doesn't hold), pass Failure.
      * @param pred predicate applied to the value held by Try
@@ -276,6 +284,11 @@ class Success<T> extends Try<T> {
     public <E extends Throwable> Try<T> onFailure(TryConsumer<Throwable, E> action) {
       return this;
     }
+
+    @Override
+    public <E extends Throwable> Try<T> raise(Class<E> clazz) throws E {
+      return this;
+    }
 }
 
 
@@ -365,4 +378,14 @@ class Failure<T> extends Try<T> {
       action.accept(e);
       return this;
     }
+
+    @Override
+    public <E extends Throwable> Try<T> raise(Class<E> clazz) throws E {
+        return onFailure( t -> {
+            if (clazz.isAssignableFrom(t.getClass())) {
+                throw (E) t;
+            }
+        } );
+    }
+
 }

--- a/src/test/java/com/jasongoodwin/monads/RaiseException.java
+++ b/src/test/java/com/jasongoodwin/monads/RaiseException.java
@@ -1,0 +1,7 @@
+package com.jasongoodwin.monads;
+
+public class RaiseException extends Exception {
+    public RaiseException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/jasongoodwin/monads/TryTest.java
+++ b/src/test/java/com/jasongoodwin/monads/TryTest.java
@@ -250,6 +250,23 @@ public class TryTest {
         });
     }
 
+    @Test( expected = RaiseException.class )
+    public void itShouldThrowCheckedExceptionOnRaiseOnFailure() throws Exception {
+        Try< String > t = Try.ofFailable( () -> {
+            throw new RaiseException( "Oops" );
+        } );
+
+        t.raise( RaiseException.class );
+    }
+
+    @Test
+    public void itShouldNotThrowCheckedExceptionOnRaiseOnSuccess() throws Throwable {
+        Try<String> t = Try.successful("success");
+        t.raise( RaiseException.class );
+
+        assertEquals( t.get(), "success" );
+    }
+
     public void itShouldNotThrowNewExceptionWhenInvokingOrElseThrowOnSuccess() throws Throwable {
         Try<String> t = Try.ofFailable(() -> "Ok");
 


### PR DESCRIPTION
this is usefull to expose (throw) exceptions that happen inside the Try monad to the outside.
